### PR TITLE
Add nl-1.platform.sh region

### DIFF
--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -24,7 +24,7 @@ class Subscription extends Resource
 {
 
     public static $availablePlans = ['development', 'standard', 'medium', 'large'];
-    public static $availableRegions = ['eu.platform.sh', 'us.platform.sh'];
+    public static $availableRegions = ['eu.platform.sh', 'us.platform.sh', 'nl-1.platform.sh'];
 
     const STATUS_ACTIVE = 'active';
     const STATUS_REQUESTED = 'requested';


### PR DESCRIPTION
Since there now a nl-1.platform.sh region too it would be nice to be able to create a project in this region from the CLI too. At this moment this is not possible because the available regions are hardcoded.

The simplest solution would be to add nl-1.platform.sh to the list of hardcoded regions but this might not be the best solution since
- at this moment the nl-1.platform.sh region is not open to everyone, so it would be ideal if we can check the regions available for the current user;
- new regions might be added in the future, so it would be ideal if new regions become available through the CLI automatically.