### PR TITLE
Let Region::$id properly reflect it's a string

### DIFF
--- a/src/Model/Region.php
+++ b/src/Model/Region.php
@@ -7,7 +7,7 @@ use GuzzleHttp\ClientInterface;
 /**
  * Represents a Platform.sh region.
  *
- * @property-read int    $id
+ * @property-read string $id
  * @property-read string $label
  * @property-read bool   $available
  * @property-read bool   $private


### PR DESCRIPTION
The `Region::$id` property was documented to be an `int`. However according to the docs (https://api.platform.sh/docs/#tag/Regions and https://api.platform.sh/docs/#operation/RestfulEntityBlimpPlatformRegion::view) it's actually a `string`.

A quick test call the the API confirms that the documentation is correct and the client is incorrect. Below is a `var_dump` of a single `Region` returned by `$this->platformClient->getRegions()`.
```
class Platformsh\Client\Model\Region#3807 (4) {
  protected $client =>
  class GuzzleHttp\Client#5367 (1) {
    private $config =>
    array(11) {
      'handler' =>
      class GuzzleHttp\HandlerStack#6558 (3) {
        ...
      }
      'headers' =>
      array(2) {
        ...
      }
      'debug' =>
      bool(false)
      'verify' =>
      bool(true)
      'proxy' =>
      NULL
      'auth' =>
      string(6) "oauth2"
      'decode_content' =>
      bool(true)
      'allow_redirects' =>
      array(5) {
        ...
      }
      'http_errors' =>
      bool(true)
      'cookies' =>
      bool(false)
      'idn_conversion' =>
      bool(true)
    }
  }
  protected $baseUrl =>
  string(43) "https://accounts.platform.sh/api/v1/regions"
  protected $data =>
  array(10) {
    'id' =>
    string(14) "us.platform.sh"
    'label' =>
    string(22) "United States (East 1)"
    'zone' =>
    string(13) "North America"
    'selection_label' =>
    string(13) "United States"
    'project_label' =>
    string(21) "United States  [US-1]"
    'provider' =>
    string(3) "AWS"
    'available' =>
    bool(false)
    'private' =>
    bool(false)
    'endpoint' =>
    string(26) "https://us.platform.sh/api"
    '_links' =>
    array(1) {
      'self' =>
      array(1) {
        ...
      }
    }
  }
  protected $isFull =>
  bool(true)
}