### PR TITLE
Expose `provider` property on `Region` model

### DIFF
--- a/src/Model/Region.php
+++ b/src/Model/Region.php
@@ -12,6 +12,7 @@ use GuzzleHttp\ClientInterface;
  * @property-read bool   $available
  * @property-read bool   $private
  * @property-read string $zone
+ * @property-read string $provider
  * @property-read string $endpoint
  */
 class Region extends ApiResourceBase


### PR DESCRIPTION
The `provider` is a property returned by the API for Regions 
and could be useful when making decisions about region 
choice.

See #41 for links to the relevant API docs and an example
API response containing the `provider` field.