### PR TITLE
2.x: Fix wrong signature for ApiResponseException::create() (depending on the Guzzle version)

### DIFF
--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -35,9 +35,10 @@ class ApiResponseException extends RequestException
     private static function alterMessage(RequestException $e)
     {
         if ($e->getResponse() !== null) {
-            $details = static::getErrorDetails($e->getResponse());
+            $details = self::getErrorDetails($e->getResponse());
             if (!empty($details)) {
-                return new static($e->getMessage() . $details, $e->getRequest(), $e->getResponse());
+                $class = \get_class($e);
+                return new $class($e->getMessage() . $details, $e->getRequest(), $e->getResponse());
             }
         }
 

--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -22,7 +22,7 @@ class ApiResponseException extends RequestException
      */
     public static function wrapGuzzleException(GuzzleException $e)
     {
-        return $e instanceof RequestException ? static::alterMessage($e) : $e;
+        return $e instanceof RequestException ? self::alterMessage($e) : $e;
     }
 
     /**


### PR DESCRIPTION
Follows from @gilzow's work in #53 