### PR TITLE
Fixed ApiResponseException::create() method to match GuzzleHttp\Exception\RequestException::create()

### DIFF
--- a/src/Exception/ApiResponseException.php
+++ b/src/Exception/ApiResponseException.php
@@ -34,11 +34,11 @@ class ApiResponseException extends RequestException
      * @inheritdoc
      */
     public static function create(
-      RequestInterface $request,
-      ResponseInterface $response = null,
-      \Exception $previous = null,
-      array $ctx = []
-    ) {
+        RequestInterface $request,
+        ResponseInterface $response = null,
+        \Throwable $previous = null,
+        array $ctx = []
+    ): parent {
         $e = parent::create($request, $response, $previous);
         if ($response === null) {
             return $e;


### PR DESCRIPTION
Closes #61 