### PR TITLE
Allow "script" as type on Integration

### DIFF
--- a/src/Model/Integration.php
+++ b/src/Model/Integration.php
@@ -31,6 +31,7 @@ class Integration extends ApiResourceBase implements HasActivitiesInterface
       'health.pagerduty',
       'health.slack',
       'health.webhook',
+      'script',
     ];
 
     /**


### PR DESCRIPTION
Hi,

Looks like this library is out of sync with the CLI.

```
$ platform integration:add

* Integration type (--type)
Enter a number to choose:
  [0 ] bitbucket
  [1 ] bitbucket_server
  [2 ] github
  [3 ] gitlab
  [4 ] hipchat
  [5 ] webhook
  [6 ] health.email
  [7 ] health.pagerduty
  [8 ] health.slack
  [9 ] health.webhook
  [10] script
```