### PR TITLE
Document `edge_hostname` on `Environment` model

### DIFF
--- a/src/Model/Environment.php
+++ b/src/Model/Environment.php
@@ -57,6 +57,8 @@ use Platformsh\Client\Model\Git\Commit;
  * @property-read array       $backups
  *   The backup configuration. It's recommended to use getBackupConfig() instead
  *   of using this array directly.
+ * @property-read string      $edge_hostname
+ *   The hostname for the edge router that serves the environment.
  */
 class Environment extends ApiResourceBase implements HasActivitiesInterface
 {


### PR DESCRIPTION
This is data that is provided by the API but since it didn't have a property
annotation it was not yet discoverable in editors.

I added the property at the end since I couldn't see any order in the listing of properties (it was neither alphabetical nor followed the API docs' order from what I could tell).