### PR TITLE
Allow to specify the start date with a DateTime object when listing the activities

### DIFF
--- a/src/Model/Activities/HasActivitiesInterface.php
+++ b/src/Model/Activities/HasActivitiesInterface.php
@@ -2,6 +2,7 @@
 
 namespace Platformsh\Client\Model\Activities;
 
+use DateTime;
 use Platformsh\Client\Model\Activity;
 
 /**
@@ -28,8 +29,8 @@ interface HasActivitiesInterface {
      *   Limit the number of activities to return. Zero for no limit.
      * @param string|null $type
      *   Filter activities by type.
-     * @param int|null    $startsAt
-     *   A UNIX timestamp for the maximum created date of activities to return.
+     * @param int|DateTime|null    $startsAt
+     *   A UNIX timestamp or DateTime for the maximum created date of activities to return.
      * @param string|string[]|null $state
      *   Filter activities by state ("pending", "in_progress", "complete" or "cancelled").
      * @param string|string[]|null $result

--- a/src/Model/Activity.php
+++ b/src/Model/Activity.php
@@ -2,6 +2,8 @@
 
 namespace Platformsh\Client\Model;
 
+use DateTime;
+use DateTimeZone;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\StreamInterface;
@@ -216,21 +218,27 @@ class Activity extends Resource
     }
 
     /**
-     * @param int $timestamp
+     * @param int|DateTime $timestamp UNIX UTC timestamp (seconds) or DateTime
      *
-     * @return false|string
+     * @return false|string 2022-02-22T02:00:00.000000+00:00
      */
     public static function formatStartsAt($timestamp)
     {
-        $tz = date_default_timezone_get();
-        date_default_timezone_set('UTC');
-        $date = date('c', $timestamp);
-        date_default_timezone_set($tz);
+        if ($timestamp instanceof DateTime) {
+            // Override the timezone to produce a UTC ISO date
+            $date = clone $timestamp;
+            $date->setTimezone(new DateTimeZone("UTC"));
+        } else {
+            // Parse the UNIX UTC timestamp (seconds) into a DateTime
+            $date = DateTime::createFromFormat('U', $timestamp, new DateTimeZone("UTC"));
+        }
+        
         if (!$date) {
             throw new \RuntimeException(sprintf('Failed to format timestamp: %d', $timestamp));
         }
-
-        return $date;
+        
+        # Sample: 2022-02-22T02:00:00.000000+00:00
+        return $date = $date->format('Y-m-d\TH:i:s.uP');
     }
 
     /**


### PR DESCRIPTION
DateTime is more reliable here, as it allows to specify microseconds and allows to catch activities more precisely.

This changes should not break compatibility, as the `formatStartsAt` method still support int timestamps (seconds). 

This is related to the bug identified in the CLI ([see bug explanation there](https://github.com/platformsh/platformsh-cli/pull/1118)).
