### PR TITLE
Find the correct app's SSH URL when no instance or default is given

### DIFF
--- a/src/Model/Environment.php
+++ b/src/Model/Environment.php
@@ -118,8 +118,8 @@ class Environment extends Resource implements HasActivitiesInterface
     public function getSshUrl($app = '', $instance = '')
     {
         $urls = $this->getSshUrls();
+        $instances = $this->getSshInstanceURLs($app, $urls);
         if ($instance !== '' && $instance !== null) {
-            $instances = $this->getSshInstanceURLs($app, $urls);
             if (isset($instances[$instance])) {
                 return $instances[$instance];
             }
@@ -131,6 +131,9 @@ class Environment extends Resource implements HasActivitiesInterface
         }
         if (isset($urls[$app])) {
             return $urls[$app];
+        }
+        if (!empty($instances)) {
+            return reset($instances);
         }
 
         // Fall back to the legacy SSH URL.

--- a/tests/Model/EnvironmentTest.php
+++ b/tests/Model/EnvironmentTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Platformsh\Client\Tests\Model;
+
+use Platformsh\Client\Model\Environment;
+
+class EnvironmentTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSshUrl()
+    {
+        $multiApp = [
+            'ssh' => ['href' => 'ssh://incorrect-fallback@ssh.example.com'],
+            'pf:ssh:app1' => ['href' => 'ssh://projectid-envmachinename--app1@ssh.example.com'],
+            'pf:ssh:app2' => ['href' => 'ssh://projectid-envmachinename--app2@ssh.example.com'],
+        ];
+        $haMultiAppWithInstanceDefault = [
+            'ssh' => ['href' => 'ssh://incorrect-fallback@ssh.example.com'],
+            'pf:ssh:app1' => ['href' => 'ssh://projectid-envmachinename--app1--2@ssh.example.com'],
+            'pf:ssh:app1:0' => ['href' => 'ssh://projectid-envmachinename--app1--0@ssh.example.com'],
+            'pf:ssh:app1:1' => ['href' => 'ssh://projectid-envmachinename--app1--1@ssh.example.com'],
+            'pf:ssh:app1:2' => ['href' => 'ssh://projectid-envmachinename--app1--2@ssh.example.com'],
+            'pf:ssh:app2' => ['href' => 'ssh://projectid-envmachinename--app1--2@ssh.example.com'],
+            'pf:ssh:app2:0' => ['href' => 'ssh://projectid-envmachinename--app2--0@ssh.example.com'],
+            'pf:ssh:app2:1' => ['href' => 'ssh://projectid-envmachinename--app2--1@ssh.example.com'],
+            'pf:ssh:app2:2' => ['href' => 'ssh://projectid-envmachinename--app2--2@ssh.example.com'],
+        ];
+        $haMultiAppNoInstanceDefault = [
+            'ssh' => ['href' => 'ssh://incorrect-fallback@ssh.example.com'],
+            'pf:ssh:app1:0' => ['href' => 'ssh://projectid-envmachinename--app1--0@ssh.example.com'],
+            'pf:ssh:app1:1' => ['href' => 'ssh://projectid-envmachinename--app1--1@ssh.example.com'],
+            'pf:ssh:app1:2' => ['href' => 'ssh://projectid-envmachinename--app1--2@ssh.example.com'],
+            'pf:ssh:app2:0' => ['href' => 'ssh://projectid-envmachinename--app2--0@ssh.example.com'],
+            'pf:ssh:app2:1' => ['href' => 'ssh://projectid-envmachinename--app2--1@ssh.example.com'],
+            'pf:ssh:app2:2' => ['href' => 'ssh://projectid-envmachinename--app2--2@ssh.example.com'],
+        ];
+
+        /** @var array{'_links': string[], 'app': string, 'instance': string, 'result': string|false}[] $cases */
+        $cases = [
+            [
+                '_links' => $multiApp,
+                'app' => 'app1',
+                'instance' => '',
+                'result' => 'projectid-envmachinename--app1@ssh.example.com',
+            ],
+            [
+                '_links' => $multiApp,
+                'app' => 'app1',
+                'instance' => '1',
+                'result' => false,
+            ],
+            [
+                '_links' => $haMultiAppWithInstanceDefault,
+                'app' => 'app1',
+                'instance' => '',
+                'result' => 'projectid-envmachinename--app1--2@ssh.example.com',
+            ],
+            [
+                '_links' => $haMultiAppWithInstanceDefault,
+                'app' => 'app1',
+                'instance' => '0',
+                'result' => 'projectid-envmachinename--app1--0@ssh.example.com',
+            ],
+            [
+                '_links' => $haMultiAppNoInstanceDefault,
+                'app' => 'app1',
+                'instance' => '',
+                'result' => 'projectid-envmachinename--app1--0@ssh.example.com',
+            ],
+            [
+                '_links' => $haMultiAppNoInstanceDefault,
+                'app' => 'app1',
+                'instance' => '1',
+                'result' => 'projectid-envmachinename--app1--1@ssh.example.com',
+            ],
+            [
+                '_links' => $haMultiAppNoInstanceDefault,
+                'app' => 'app1',
+                'instance' => '3',
+                'result' => false,
+            ],
+            [
+                '_links' => $haMultiAppNoInstanceDefault,
+                'app' => 'app2',
+                'instance' => '',
+                'result' => 'projectid-envmachinename--app2--0@ssh.example.com',
+            ],
+        ];
+        foreach ($cases as $i => $case) {
+            $environment = new Environment(['id' => 'main', 'status' => 'active', '_links' => $case['_links']], 'https://example.com/projects/foo');
+            if ($case['result'] === false) {
+                try {
+                    $environment->getSshUrl($case['app'], $case['instance']);
+                } catch (\InvalidArgumentException $e) {
+                    $this->assertContains('SSH URL not found for instance', $e->getMessage(), "case $i");
+                }
+                continue;
+            }
+            $result = $environment->getSshUrl($case['app'], $case['instance']);
+            $this->assertEquals($case['result'], $result, "case $i");
+        }
+    }
+}


### PR DESCRIPTION
This uses the instance-based SSH URL if an app default URL is not available and the $instance is not provided. So it avoids falling back to the environment's default SSH URL in more cases.