### PR TITLE
Fix getSubscriptions when an organization is set

### DIFF
--- a/src/PlatformClient.php
+++ b/src/PlatformClient.php
@@ -368,7 +368,7 @@ class PlatformClient
     public function getSubscriptions($organizationId = null)
     {
         if (isset($organizationId)) {
-            $url = $this->apiUrl() . '/' . $organizationId . '/subscriptions';
+            $url = $this->apiUrl() . '/organizations/' . $organizationId . '/subscriptions';
         } else {
             $url = $this->apiUrl() . '/subscriptions';
         }


### PR DESCRIPTION
API endpoints /organizations/ must be explicitly used.