### PR TITLE
Fix getAccessToken() return type

### DIFF
--- a/src/Connection/Connector.php
+++ b/src/Connection/Connector.php
@@ -207,7 +207,7 @@ class Connector implements ConnectorInterface
     /**
      * Returns the access token saved in the session, if any.
      */
-    public function getAccessToken(): false|string
+    public function getAccessToken(): ?string
     {
         return $this->session->get('accessToken');
     }


### PR DESCRIPTION
## Summary

- Fix `Connector::getAccessToken()` return type from `false|string` to `?string`
- `Session::get()` returns null when the key is absent, but the declared type did not include null
- The method never returned `false`; removing it from the union is a correction, not a behavior change

## Test plan

- [ ] Verify CLI auth with no cached session (e.g. fresh container with `PLATFORMSH_CLI_TOKEN`)
- [ ] Confirm existing session-based auth still works

Generated with [Claude Code](https://claude.com/claude-code)