### PR TITLE
Add PHPStan static analysis at level 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,11 @@ jobs:
             - name: Install dependencies
               run: composer install --no-progress --no-suggest --no-interaction
 
+            - name: Run ECS
+              run: ./vendor/bin/ecs check
+
+            - name: Run PHPStan
+              run: ./vendor/bin/phpstan analyse
+
             - name: Run PHPUnit tests
               run: ./vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: lint lint-ecs lint-phpstan test
+
+lint: lint-ecs lint-phpstan
+
+lint-ecs:
+	./vendor/bin/ecs check
+
+lint-phpstan:
+	./vendor/bin/phpstan analyse
+
+test:
+	./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^11",
-        "symplify/easy-coding-standard": "^12.3"
+        "symplify/easy-coding-standard": "^12.3",
+        "phpstan/phpstan": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2270ce21cd19828005c1bfc9d52bb0c1",
+    "content-hash": "794490c0731ed9c687212caf94f30214",
     "packages": [
         {
             "name": "cocur/slugify",
@@ -1134,6 +1134,59 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.42",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-17T14:58:32+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,61 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Activity.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Organization/Address.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Model/Organization/Organization.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Organization/Organization.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Organization/Profile.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Ref/Resolver.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:get\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/SetupOptions.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/Team/Team.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:patch\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Model/UserAccess/ProjectUserAccess.php
+
+		-
+			message: '#^Call to an undefined method GuzzleHttp\\ClientInterface\:\:post\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/PlatformClient.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 5
+	paths:
+		- src
+		- tests
+	ignoreErrors:
+		# Deliberate pattern: resource classes use new static() for polymorphism.
+		-
+			identifier: new.static

--- a/src/Connection/ConnectorInterface.php
+++ b/src/Connection/ConnectorInterface.php
@@ -54,6 +54,16 @@ interface ConnectorInterface
     public function setApiToken(string $token, string $type);
 
     /**
+     * Get the connector configuration.
+     */
+    public function getConfig(): array;
+
+    /**
+     * Returns the access token saved in the session, if any.
+     */
+    public function getAccessToken(): ?string;
+
+    /**
      * Get the configured API gateway URL (without trailing slash).
      */
     public function getApiUrl(): string;

--- a/src/Model/ActivityLog/LogItem.php
+++ b/src/Model/ActivityLog/LogItem.php
@@ -34,7 +34,7 @@ class LogItem
      */
     public static function singleFromJson(string $str): self|false
     {
-        $data = static::decode($str);
+        $data = self::decode($str);
         if (isset($data['data']['timestamp'], $data['data']['message'])) {
             $id = isset($data['_id']) ? (string) $data['_id'] : '';
             return new static($data['data']['timestamp'], $data['data']['message'], $id);
@@ -43,7 +43,7 @@ class LogItem
     }
 
     /**
-     * @return static[]
+     * @return self[]
      *@deprecated use LogItem::multipleFromJsonStreamWithSeal() instead
      */
     public static function multipleFromJsonStream(string $str): array
@@ -77,7 +77,7 @@ class LogItem
             if ($line === '') {
                 continue;
             }
-            $data = static::decode($line);
+            $data = self::decode($line);
             if (is_array($data)) {
                 if (! empty($data['seal'])) {
                     $seal = true;

--- a/src/Model/AutoscalingSettings.php
+++ b/src/Model/AutoscalingSettings.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Platformsh\Client\Model;
 
 /**
  * Represents environment autoscaling settings.
- *
  */
-class AutoscalingSettings extends ApiResourceBase {}
+class AutoscalingSettings extends ApiResourceBase
+{
+}

--- a/src/Model/Backups/RestoreOptions.php
+++ b/src/Model/Backups/RestoreOptions.php
@@ -16,45 +16,30 @@ class RestoreOptions
 
     private ?string $resourcesInit;
 
-    /**
-     * @return RestoreOptions
-     */
     public function setEnvironmentName(?string $environmentName): static
     {
         $this->environmentName = $environmentName;
         return $this;
     }
 
-    /**
-     * @return RestoreOptions
-     */
     public function setBranchFrom(?string $branchFrom): static
     {
         $this->branchFrom = $branchFrom;
         return $this;
     }
 
-    /**
-     * @return RestoreOptions
-     */
     public function setRestoreCode(?bool $restoreCode): static
     {
         $this->restoreCode = $restoreCode;
         return $this;
     }
 
-    /**
-     * @return RestoreOptions
-     */
     public function setRestoreResources(?bool $restoreResources): static
     {
         $this->restoreResources = $restoreResources;
         return $this;
     }
 
-    /**
-     * @return RestoreOptions
-     */
     public function setResourcesInit(?string $init): static
     {
         $this->resourcesInit = $init;

--- a/src/Model/Git/Tree.php
+++ b/src/Model/Git/Tree.php
@@ -68,14 +68,11 @@ class Tree extends ApiResourceBase
         if ($object === false) {
             return false;
         }
-        if ($object instanceof Blob) {
-            return $object;
-        }
         if ($object instanceof self) {
             throw new GitObjectTypeException('The requested file is a directory', $path);
         }
 
-        return false;
+        return $object;
     }
 
     /**

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -508,7 +508,7 @@ class Project extends ApiResourceBase implements HasActivitiesInterface
     /**
      * Returns system information about the project, e.g. the API version.
      */
-    public function systemInformation(): System
+    public function systemInformation(): System|false
     {
         return System::get($this->getLink('#system'), '', $this->client);
     }

--- a/src/Model/Ref/Resolver.php
+++ b/src/Model/Ref/Resolver.php
@@ -38,7 +38,7 @@ class Resolver
             return $data;
         }
         foreach ($data['_links'] as $key => $link) {
-            if (str_starts_with($key, 'ref:') && ($parts = \explode(':', $key, 3)) && \count($parts) === 3) {
+            if (str_starts_with($key, 'ref:') && \count($parts = \explode(':', $key, 3)) === 3) {
                 $set = $parts[1];
                 $linkUri = Utils::uriFor($link['href']);
                 $absoluteUrl = Utils::uriFor($this->baseUrl)->withPath($linkUri->getPath())->withQuery($linkUri->getQuery());

--- a/src/Model/ResourceWithReferences.php
+++ b/src/Model/ResourceWithReferences.php
@@ -106,7 +106,7 @@ class ResourceWithReferences extends ApiResourceBase
                 $data = $resolver->resolveReferences($data);
             } catch (\Exception $e) {
                 $message = $e->getMessage();
-                if ($e instanceof BadResponseException && $e->getResponse()) {
+                if ($e instanceof BadResponseException) {
                     $message = \sprintf('status code %d', $e->getResponse()->getStatusCode());
                 }
                 \trigger_error('Unable to resolve references: ' . $message, E_USER_WARNING);

--- a/src/Model/Result.php
+++ b/src/Model/Result.php
@@ -75,7 +75,7 @@ class Result extends ApiResourceBase
      */
     public function getEntity(): ApiResourceBase
     {
-        if (! isset($this->data['_embedded']['entity']) || ! isset($this->resourceClass)) {
+        if (! isset($this->data['_embedded']['entity'])) {
             throw new \Exception('No entity found in result');
         }
 

--- a/src/Model/Settings.php
+++ b/src/Model/Settings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Platformsh\Client\Model;
 
 /**
@@ -7,4 +9,6 @@ namespace Platformsh\Client\Model;
  *
  * @property-read bool $enable_manual_deployments
  */
-class Settings extends ApiResourceBase {}
+class Settings extends ApiResourceBase
+{
+}

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -69,7 +69,7 @@ class Subscription extends ResourceWithReferences
     {
         $result = parent::create($body, $collectionUrl, $client);
 
-        return new self($result->getData(), $collectionUrl, $client);
+        return new static($result->getData(), $collectionUrl, $client);
     }
 
     /**

--- a/src/PlatformClient.php
+++ b/src/PlatformClient.php
@@ -592,8 +592,6 @@ class PlatformClient
      * @param string $country An ISO 2-letter country code.
      * @param string $owner The organization owner ID. Leave empty to use the current user.
      * @param string $type The organization type. Leave blank to use the default.
-     *
-     * @return Organization
      */
     public function createOrganization(string $name, string $label = '', string $country = '', string $owner = '', string $type = ''): Organization
     {
@@ -643,6 +641,9 @@ class PlatformClient
      */
     protected function locateProject(string $id): false|string
     {
+        if (! $this->connector instanceof Connector) {
+            return false;
+        }
         $url = rtrim($this->connector->getAccountsEndpoint(), '/') . '/projects/' . rawurlencode($id);
         try {
             $result = $this->simpleGet($url);
@@ -678,7 +679,12 @@ class PlatformClient
      */
     private function apiUrl(): string
     {
-        return $this->connector->getApiUrl() ?: rtrim($this->connector->getAccountsEndpoint(), '/');
+        $url = $this->connector->getApiUrl();
+        if ($url === '' && $this->connector instanceof Connector) {
+            $url = rtrim($this->connector->getAccountsEndpoint(), '/');
+        }
+
+        return $url;
     }
 
     /**

--- a/tests/Model/EnvironmentTest.php
+++ b/tests/Model/EnvironmentTest.php
@@ -76,7 +76,6 @@ class EnvironmentTest extends TestCase
             ],
         ];
 
-        /** @var array{'_links': string[], 'app': string, 'instance': string, 'result': string|false}[] $cases */
         $cases = [
             [
                 '_links' => $multiApp,


### PR DESCRIPTION
## Summary

- Add `phpstan/phpstan ^2` at level 5 with a baseline of 11 errors (all `ClientInterface::get/patch/post()` shorthand methods not on the Guzzle interface)
- Globally ignore `new.static` (deliberate polymorphism pattern across the resource model)
- Add ECS and PHPStan steps to GitHub Actions CI workflow
- Add Makefile with `lint-ecs`, `lint-phpstan`, and `test` targets

### PHPStan fixes

- `Project::systemInformation()` return type missing `false` case
- `RestoreOptions`: remove redundant `@return` PHPDocs conflicting with native `static` return type
- `LogItem`: `static::` to `self::` for private method call
- `Tree::getBlob()`: reorder to guard clauses first, remove dead code
- `Resolver`: simplify always-true `explode()` assignment in condition
- `ResourceWithReferences`: remove always-true `getResponse()` check (`BadResponseException` always has a response)
- `Result::getEntity()`: remove redundant `isset()` on initialized property
- `Subscription::create()`: `new self()` to `new static()` to match return type

### ConnectorInterface

- Add `getConfig()` and `getAccessToken()` to `ConnectorInterface`
- Guard deprecated `getAccountsEndpoint()` calls behind `instanceof Connector`

### ECS

- Fix 3 violations: missing `declare(strict_types=1)`, brace style, superfluous `@return`

## Test plan

- [x] `make lint` passes (ECS + PHPStan)
- [x] `make test` passes (PHPUnit)
- [x] CI workflow runs all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)