### PR TITLE
Make nullability of types explicit

### DIFF
--- a/src/Connection/Connector.php
+++ b/src/Connection/Connector.php
@@ -86,7 +86,7 @@ class Connector implements ConnectorInterface
      *       received. It will be passed a Guzzle ResponseInterface, and
      *       should return an AccessToken or null.
      */
-    public function __construct(array $config = [], SessionInterface $session = null)
+    public function __construct(array $config = [], ?SessionInterface $session = null)
     {
         if (isset($config['accounts'])) {
             \trigger_error('The "accounts" URL option is deprecated. APIs are accessed based on the "api_url" and OAuth 2.0 URL options instead.', E_USER_DEPRECATED);
@@ -216,7 +216,7 @@ class Connector implements ConnectorInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      */
-    public function logIn(string $username, string $password, bool $force = false, int|string $totp = null): void
+    public function logIn(string $username, string $password, bool $force = false, null|int|string $totp = null): void
     {
         if (! $force && $this->isLoggedIn() && $this->session->get('username') === $username) {
             return;

--- a/src/Connection/ConnectorInterface.php
+++ b/src/Connection/ConnectorInterface.php
@@ -23,7 +23,7 @@ interface ConnectorInterface
      * @param int|string|null $totp
      *   Time-based one-time password (two-factor authentication).
      */
-    public function logIn(string $username, string $password, bool $force = false, int|string $totp = null);
+    public function logIn(string $username, string $password, bool $force = false, null|int|string $totp = null);
 
     /**
      * Log out.

--- a/src/Exception/ProjectReferenceException.php
+++ b/src/Exception/ProjectReferenceException.php
@@ -14,7 +14,7 @@ class ProjectReferenceException extends \RuntimeException
     /**
      * @param string|null $message
      */
-    public function __construct(string $projectId, $message = null, \Exception $previous = null)
+    public function __construct(string $projectId, $message = null, ?\Exception $previous = null)
     {
         $this->projectId = $projectId;
         $message = $message ?: 'Cannot resolve reference for project: ' . $projectId;

--- a/src/Model/Activities/HasActivitiesInterface.php
+++ b/src/Model/Activities/HasActivitiesInterface.php
@@ -36,5 +36,5 @@ interface HasActivitiesInterface
      *
      * @return Activity[]
      */
-    public function getActivities(int $limit = 0, array|string $type = null, DateTime|int $startsAt = null, array|string $state = null, array|string $result = null): array;
+    public function getActivities(int $limit = 0, null|array|string $type = null, null|DateTime|int $startsAt = null, null|array|string $state = null, null|array|string $result = null): array;
 }

--- a/src/Model/Activities/HasActivitiesTrait.php
+++ b/src/Model/Activities/HasActivitiesTrait.php
@@ -19,7 +19,7 @@ trait HasActivitiesTrait
         return Activity::get($id, $this->getUri() . '/activities', $this->client);
     }
 
-    public function getActivities(int $limit = 0, array|string $type = null, DateTime|int $startsAt = null, array|string $state = null, array|string $result = null): array
+    public function getActivities(int $limit = 0, null|array|string $type = null, null|DateTime|int $startsAt = null, null|array|string $state = null, null|array|string $result = null): array
     {
         $query = '';
         if ($type !== null) {

--- a/src/Model/Activity.php
+++ b/src/Model/Activity.php
@@ -63,7 +63,7 @@ class Activity extends ApiResourceBase
      *                                string. Deprecated: use readLog() instead.
      * @param float|int $pollInterval The polling interval, in seconds.
      */
-    public function wait(callable $onPoll = null, callable $onLog = null, float|int $pollInterval = 1): void
+    public function wait(?callable $onPoll = null, ?callable $onLog = null, float|int $pollInterval = 1): void
     {
         $log = $this->getProperty('log');
         $length = strlen($log);
@@ -109,7 +109,7 @@ class Activity extends ApiResourceBase
      *
      * @return LogItem[]
      */
-    public function readLog(callable $onUpdate = null): array
+    public function readLog(?callable $onUpdate = null): array
     {
         $response = $this->fetchLog($onUpdate !== null);
         $body = $response->getBody();
@@ -151,7 +151,7 @@ class Activity extends ApiResourceBase
      *                                (depending on $target), this specifies
      *                                the name of the parent branch.
      */
-    public function restore(string $target = null, string $branchFrom = null): self
+    public function restore(?string $target = null, ?string $branchFrom = null): self
     {
         if ($this->getProperty('type') !== 'environment.backup') {
             throw new \BadMethodCallException('Cannot restore activity (wrong type)');

--- a/src/Model/ApiResourceBase.php
+++ b/src/Model/ApiResourceBase.php
@@ -45,7 +45,7 @@ abstract class ApiResourceBase implements \ArrayAccess
      * @param bool $full    Whether the data is a complete
      *                                 representation of the resource.
      */
-    public function __construct(array $data, string $baseUrl = null, ClientInterface $client = null, bool $full = true)
+    public function __construct(array $data, ?string $baseUrl = null, ?ClientInterface $client = null, bool $full = true)
     {
         $this->client = $client ?: new Client();
         $this->baseUrl = (string) $baseUrl;
@@ -565,7 +565,7 @@ abstract class ApiResourceBase implements \ArrayAccess
     /**
      * Make a URL absolute, based on the base URL.
      */
-    protected function makeAbsoluteUrl(string $relativeUrl, string $baseUrl = null): string
+    protected function makeAbsoluteUrl(string $relativeUrl, ?string $baseUrl = null): string
     {
         $baseUrl = $baseUrl ?: $this->baseUrl;
         if (empty($baseUrl)) {

--- a/src/Model/Backup.php
+++ b/src/Model/Backup.php
@@ -28,7 +28,7 @@ class Backup extends ApiResourceBase
     /**
      * Restores a backup.
      */
-    public function restore(RestoreOptions $options = null): Result
+    public function restore(?RestoreOptions $options = null): Result
     {
         return $this->runOperation('restore', 'POST', $options ? $options->toArray() : []);
     }

--- a/src/Model/Billing/PlanRecordQuery.php
+++ b/src/Model/Billing/PlanRecordQuery.php
@@ -11,7 +11,7 @@ class PlanRecordQuery
     /**
      * Restrict the query to a date/time period.
      */
-    public function setPeriod(\DateTime $start = null, \DateTime $end = null): void
+    public function setPeriod(?\DateTime $start = null, ?\DateTime $end = null): void
     {
         $this->filters['start'] = $start?->format('c');
         $this->filters['end'] = $end?->format('c');

--- a/src/Model/Environment.php
+++ b/src/Model/Environment.php
@@ -169,7 +169,7 @@ class Environment extends ApiResourceBase implements HasActivitiesInterface
      * @return array<mixed, string>
      *     An array of SSH URLs for the given app, keyed by instance ID.
      */
-    public function getSshInstanceURLs(string $app, array $sshUrls = null): array
+    public function getSshInstanceURLs(string $app, ?array $sshUrls = null): array
     {
         $urls = $sshUrls === null ? $this->getSshUrls() : $sshUrls;
         $instances = [];
@@ -270,7 +270,7 @@ class Environment extends ApiResourceBase implements HasActivitiesInterface
      *
      * @deprecated use instead: runOperation('branch', 'POST', ['name' => 'git-branch-name', 'title' => 'Untitled', 'clone_parent' => true, 'type' => 'development'])
      */
-    public function branch(string $title, string $id = null, bool $cloneParent = true, string $type = null): Activity
+    public function branch(string $title, ?string $id = null, bool $cloneParent = true, ?string $type = null): Activity
     {
         $id = $id ?: $this->sanitizeId($title);
         $body = [

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -41,7 +41,7 @@ class Project extends ApiResourceBase implements HasActivitiesInterface
      * do not always contain full information about each project. So this
      * overrides the Resource constructor to default $full to false.
      */
-    public function __construct(array $data, $baseUrl = null, ClientInterface $client = null, $full = false)
+    public function __construct(array $data, $baseUrl = null, ?ClientInterface $client = null, $full = false)
     {
         parent::__construct($data, $baseUrl, $client, $full);
     }
@@ -278,7 +278,7 @@ class Project extends ApiResourceBase implements HasActivitiesInterface
      *
      * @return Environment[]
      */
-    public function getEnvironments(int $limit = 0, string $type = null, bool $active = null): array
+    public function getEnvironments(int $limit = 0, ?string $type = null, ?bool $active = null): array
     {
         $options = [];
         if ($type !== null) {

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -80,7 +80,7 @@ class Subscription extends ResourceWithReferences
      *                            one argument: the Subscription object.
      * @param int $interval The polling interval, in seconds.
      */
-    public function wait(callable $onPoll = null, int $interval = 2): void
+    public function wait(?callable $onPoll = null, int $interval = 2): void
     {
         while ($this->isPending()) {
             sleep(max($interval, 1));

--- a/src/PlatformClient.php
+++ b/src/PlatformClient.php
@@ -45,7 +45,7 @@ class PlatformClient
      */
     protected false|null|string $userId;
 
-    public function __construct(ConnectorInterface $connector = null)
+    public function __construct(?ConnectorInterface $connector = null)
     {
         $this->connector = $connector ?: new Connector();
     }
@@ -58,7 +58,7 @@ class PlatformClient
     /**
      * Get a single project by its ID.
      */
-    public function getProject(string $id, string $hostname = null, bool $https = true): Project|false
+    public function getProject(string $id, ?string $hostname = null, bool $https = true): Project|false
     {
         // Look for a project directly if the hostname is known.
         if ($hostname !== null) {
@@ -128,7 +128,7 @@ class PlatformClient
      * @return BasicProjectInfo[]
      *   A list of basic project information.
      */
-    public function getMyProjects(string $vendor = null): array
+    public function getMyProjects(?string $vendor = null): array
     {
         $projects = [];
         if (! empty($this->connector->getConfig()['centralized_permissions_enabled'])) {
@@ -242,7 +242,7 @@ class PlatformClient
      * @param string $value The SSH key value.
      * @param string|null $title A title for the key (optional).
      */
-    public function addSshKey(string $value, string $title = null): Result
+    public function addSshKey(string $value, ?string $title = null): Result
     {
         $values = $this->cleanRequest([
             'value' => $value,
@@ -275,7 +275,7 @@ class PlatformClient
      * @see PlatformClient::getRegions()
      * @see Subscription::wait()
      */
-    public function createSubscription(SubscriptionOptions|string $options, string $plan = null, string $title = null, int $storage = null, int $environments = null, array $activation_callback = null, string $options_url = null): Subscription
+    public function createSubscription(SubscriptionOptions|string $options, ?string $plan = null, ?string $title = null, ?int $storage = null, ?int $environments = null, ?array $activation_callback = null, ?string $options_url = null): Subscription
     {
         if ($options instanceof SubscriptionOptions) {
             $values = $options->toArray();
@@ -310,7 +310,7 @@ class PlatformClient
      *
      * @return Subscription[]
      */
-    public function getSubscriptions(string $organizationId = null): array
+    public function getSubscriptions(?string $organizationId = null): array
     {
         if (isset($organizationId)) {
             $url = $this->apiUrl() . '/organizations/' . $organizationId . '/subscriptions';
@@ -341,7 +341,7 @@ class PlatformClient
      *
      * @return array An array containing at least 'total' (a formatted price).
      */
-    public function getSubscriptionEstimate(string $plan, int $storage, int $environments, int $users, string $countryCode = null, string $organizationId = null): array
+    public function getSubscriptionEstimate(string $plan, int $storage, int $environments, int $users, ?string $countryCode = null, ?string $organizationId = null): array
     {
         $options = [];
         $options['query'] = [
@@ -390,7 +390,7 @@ class PlatformClient
      *
      * @return PlanRecord[]
      */
-    public function getPlanRecords(PlanRecordQuery $query = null): array
+    public function getPlanRecords(?PlanRecordQuery $query = null): array
     {
         $url = $this->apiUrl() . '/records/plan';
         $options = [];
@@ -446,7 +446,7 @@ class PlatformClient
      * @param string|null $username           The name of the account for which the project is to be created.
      * @param string|null $organization       The name of the organization for which the project is to be created.
      */
-    public function getSetupOptions(string $vendor = null, string $plan = null, string $options_url = null, string $username = null, string $organization = null): SetupOptions
+    public function getSetupOptions(?string $vendor = null, ?string $plan = null, ?string $options_url = null, ?string $username = null, ?string $organization = null): SetupOptions
     {
         $url = $this->apiUrl() . '/setup/options';
         $options = $this->cleanRequest([
@@ -466,7 +466,7 @@ class PlatformClient
      * @param string|null $id
      *   The user ID. Defaults to the current user.
      */
-    public function getUser(string $id = null): false|User
+    public function getUser(?string $id = null): false|User
     {
         if (! $this->connector->getApiUrl()) {
             throw new \RuntimeException('No API URL configured');
@@ -620,7 +620,7 @@ class PlatformClient
      *
      *@throws \RuntimeException if the given organization and team IDs conflict
      */
-    public function getTeam(string $id, Organization $organization = null): false|Team
+    public function getTeam(string $id, ?Organization $organization = null): false|Team
     {
         if (! $this->connector->getApiUrl()) {
             throw new \RuntimeException('No API URL configured');

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -22,7 +22,7 @@ class Session implements SessionInterface
      * @param string $id   A unique session ID.
      * @param array                   $data Initial session data.
      */
-    public function __construct(string $id = 'default', array $data = [], SessionStorageInterface $storage = null)
+    public function __construct(string $id = 'default', array $data = [], ?SessionStorageInterface $storage = null)
     {
         $this->id = $id;
         $this->data = $data;

--- a/src/Session/Storage/File.php
+++ b/src/Session/Storage/File.php
@@ -17,7 +17,7 @@ class File implements SessionStorageInterface
      *   A writable directory where session files will be saved. Leave null
      *   to use the default.
      */
-    public function __construct(string $directory = null)
+    public function __construct(?string $directory = null)
     {
         $this->directory = $directory ?: $this->getDefaultDirectory();
     }


### PR DESCRIPTION
Implicit NULL [is deprecated as of PHP 8.4](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)